### PR TITLE
Redirect to new Ferdium releases

### DIFF
--- a/download.html
+++ b/download.html
@@ -1,1 +1,1 @@
-<meta http-equiv="Refresh" content="0; url='https://github.com/ferdium/ferdi/releases'" />
+<meta http-equiv="Refresh" content="0; url='https://github.com/ferdium/ferdium-app/releases'" />


### PR DESCRIPTION
Previously, we were redirecting to our mirror of Ferdi releases.
Since we now have nightly releases up, we should redirect `/download` to those instead.