### PR TITLE
Adjust width of code block section

### DIFF
--- a/components/CodeBlockSection.tsx
+++ b/components/CodeBlockSection.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const CodeBlockSection = (props: Props) => {
   return (
-    <article style={{ width: "450px", marginBottom: "1rem" }}>
+    <article style={{ width: "500px", marginBottom: "1rem" }}>
       <h3>{props.title}</h3>
       <CodeBlock code={props.text} />
     </article>


### PR DESCRIPTION
The Snap section is a bit too cramped, causing the copy button to appear outside the element.

This is currently fixed by making the code block section wider. The alternative would be to allow line wrapping or vertical overflow scrolling.