### PR TITLE
Fix: Codeblocks overflowing and breaking page style

### DIFF
--- a/components/CodeBlockSection.tsx
+++ b/components/CodeBlockSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import CodeBlock from "./CodeBlock";
-
+import styles from "styles/components/CodeBlockSection.module.scss";
 type Props = {
   text: string;
   title: string;
@@ -8,7 +8,7 @@ type Props = {
 
 const CodeBlockSection = (props: Props) => {
   return (
-    <article style={{ width: "500px", marginBottom: "1rem" }}>
+    <article className={styles.codeblocksection}>
       <h3>{props.title}</h3>
       <CodeBlock code={props.text} />
     </article>

--- a/styles/components/CodeBlock.module.scss
+++ b/styles/components/CodeBlock.module.scss
@@ -19,6 +19,7 @@
   white-space: pre;
   margin-right: vars.$unit;
   line-height: 1.5rem;
+  overflow-x: scroll;
 }
 .check {
   & * {

--- a/styles/components/CodeBlockSection.module.scss
+++ b/styles/components/CodeBlockSection.module.scss
@@ -1,0 +1,7 @@
+@use "../vars.module.scss";
+
+.codeblocksection {
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 500px;
+}


### PR DESCRIPTION
A fix for the styling issue on the download page 
https://discord.com/channels/963836780778512454/967774711348072498/989128056063021116